### PR TITLE
chore: tweak module name, follow go mod major version update docs

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
       - uses: reviewdog/action-staticcheck@v1
         with:
           github_token: ${{ secrets.github_token }}

--- a/examples/sum.go
+++ b/examples/sum.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/kevwan/mapreduce"
+	"github.com/kevwan/mapreduce/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kevwan/mapreduce
+module github.com/kevwan/mapreduce/v2
 
 go 1.18
 

--- a/readme-cn.md
+++ b/readme-cn.md
@@ -64,7 +64,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/kevwan/mapreduce"
+    "github.com/kevwan/mapreduce/v2"
 )
 
 func main() {

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ import (
     "fmt"
     "log"
 
-    "github.com/kevwan/mapreduce"
+    "github.com/kevwan/mapreduce/v2"
 )
 
 func main() {


### PR DESCRIPTION
Update module path to `github.com/kevwan/mapreduce/v2`. 


https://go.dev/doc/modules/major-version